### PR TITLE
macOSでビルドに失敗する箇所の修正

### DIFF
--- a/src/dos_file.c
+++ b/src/dos_file.c
@@ -71,7 +71,7 @@ Long Read(UWord fileno, ULong buffer, ULong length) {
 
 // Human68kにおける2バイト文字の1バイト目の文字コードか
 static int is_mb_lead(char c) {
-  return (0x80 <= c && c <= 0x9f) || (0xe0 <= c && 0xff);
+  return (0x80 <= c && c <= 0x9f) || (0xe0 <= c && c <= 0xfc);
 }
 
 // 最後のパスデリミタ(\ : /)の次のアドレスを求める

--- a/src/host_misc.c
+++ b/src/host_misc.c
@@ -21,7 +21,7 @@
 #include "run68.h"
 
 // IOCS _ONTIME (0x7f)
-RegPair IocsOntime_win32(void) {
+RegPair IocsOntime_time(void) {
   time_t t = time(NULL);
   const int secondsPerDay = 24 * 60 * 60;
   return (RegPair){(t % secondsPerDay) * 100, (t / secondsPerDay) & 0xffff};


### PR DESCRIPTION
手元のmacOSでビルドが通るように修正してみました。

ちなみにsrc/dos_file.cの修正はmacOS以外でも何かしらコンパイラから指摘されそうな気がしますが、そうでもないでしょうか。
手元の環境では下記エラーが出ました。
```
[1/32] Building C object CMakeFiles/run68.dir/src/dos_file.c.o
FAILED: CMakeFiles/run68.dir/src/dos_file.c.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DUSE_ICONV  -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -funsigned-char -O3 -Wall -Wextra -Werror -Wno-unused-parameter -MD -MT CMakeFiles/run68.dir/src/dos_file.c.o -MF CMakeFiles/run68.dir/src/dos_file.c.o.d -o CMakeFiles/run68.dir/src/dos_file.c.o -c /Users/don/src/x68k/run68x/src/dos_file.c
/Users/don/src/x68k/run68x/src/dos_file.c:74:49: error: use of logical '&&' with constant operand [-Werror,-Wconstant-logical-operand]
  return (0x80 <= c && c <= 0x9f) || (0xe0 <= c && 0xff);
                                                ^  ~~~~
/Users/don/src/x68k/run68x/src/dos_file.c:74:49: note: use '&' for a bitwise operation
  return (0x80 <= c && c <= 0x9f) || (0xe0 <= c && 0xff);
                                                ^~
                                                &
/Users/don/src/x68k/run68x/src/dos_file.c:74:49: note: remove constant to silence this warning
  return (0x80 <= c && c <= 0x9f) || (0xe0 <= c && 0xff);
                                               ~^~~~~~~
1 error generated.
```