### PR TITLE
feat: replace date and time calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # run68x 2.0.5-beta.1
 
-* `IOCS _DATEGET`で月の値が1小さい不具合を修正。
+* `DOS _SETTIM2`、`DOS _SETDATE`でホスト環境の時計を変更しないように仕様変更。
+  エラー時の返り値を-1に変更。
+* (generic) `IOCS _DATEGET`で月の値が1小さい不具合を修正。
 * `IOCS _TIMEGET`で24時間計を示すフラグが0になっている不具合を修正。
-* 下記IOCSコールを実装。
+* 下記DOSコール、IOCSコールを実装。
+  * `DOS _SETTIME` (ホスト環境の時計を変更せず、0またはエラーコードを返すのみ)
   * `IOCS _DATEBCD`
-  * `IOCS _DATESET` (ホスト環境への設定は行わず0を返すのみ)
+  * `IOCS _DATESET` (ホスト環境の時計を変更せず、0を返すのみ)
   * `IOCS _TIMEBCD`
-  * `IOCS _TIMESET` (ホスト環境への設定は行わず0を返すのみ)
+  * `IOCS _TIMESET` (ホスト環境の時計を変更せず、0を返すのみ)
 
 
 # run68x 2.0.4 (2024-10-24)

--- a/src/iocscall.h
+++ b/src/iocscall.h
@@ -1,0 +1,38 @@
+// run68x - Human68k CUI Emulator based on run68
+// Copyright (C) 2024 TcbnErik
+//
+// This program is free software; you can redistribute it and /or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110 - 1301 USA.
+
+#ifndef IOCSCALL_H
+#define IOCSCALL_H
+
+#include <time.h>
+
+#include "run68.h"
+
+typedef time_t (*TimeFunc)(time_t *);
+
+ULong Datebcd(ULong bcd);
+ULong Dateset(ULong bcd);
+ULong Timebcd(ULong bcd);
+ULong Timeset(ULong bcd);
+ULong Dateget(TimeFunc timeFunc);
+ULong Datebin(Long bcd);
+ULong Timeget(TimeFunc timeFunc);
+ULong Timebin(Long bcd);
+
+bool iocs_call(void);
+
+#endif

--- a/src/line_4.c
+++ b/src/line_4.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "iocscall.h"
 #include "operate.h"
 #include "run68.h"
 


### PR DESCRIPTION
* `DOS _SETTIM2`、`DOS _SETDATE`でホスト環境の時計を変更しないように仕様変更。
* 下記DOSコールを実装。
  * `DOS _SETTIME` (ホスト環境の時計を変更せず、0またはエラーコードを返すのみ)
