### PR TITLE
refactor: avoid warnings in ctype functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,11 @@ else()
   target_link_libraries(${PROJECT_NAME} PRIVATE m)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
+  # Avoid warnings in ctype functions
+  target_compile_options(${PROJECT_NAME} PRIVATE -Wno-char-subscripts)
+endif()
+
 if(USE_ICONV)
   find_package(Iconv REQUIRED)
   target_compile_definitions(${PROJECT_NAME} PRIVATE USE_ICONV)

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1,5 +1,5 @@
 // run68x - Human68k CUI Emulator based on run68
-// Copyright (C) 2024 TcbnErik
+// Copyright (C) 2025 TcbnErik
 //
 // This program is free software; you can redistribute it and /or modify
 // it under the terms of the GNU General Public License as published by
@@ -96,7 +96,7 @@ static void splitCommandLine(const char* s, char* buf, int* argc, char** argv) {
 
   for (;;) {
     // 空白文字を読み飛ばす
-    while (isblank((int)*s)) s++;
+    while (isblank(*s)) s++;
     if (*s == '\0') break;
 
     // トークンの先頭
@@ -104,7 +104,7 @@ static void splitCommandLine(const char* s, char* buf, int* argc, char** argv) {
     *argc += 1;
 
     // トークンの終端まで読み進む
-    while (*s != '\0' && !isblank((int)*s)) {
+    while (*s != '\0' && !isblank(*s)) {
       *buf++ = *s++;
     }
     *buf++ = '\0';
@@ -114,7 +114,7 @@ static void splitCommandLine(const char* s, char* buf, int* argc, char** argv) {
 static char* toUpperString(char* s) {
   char* p = s;
   while (*p) {
-    *p = toupper((int)*p);
+    *p = toupper(*p);
     p += 1;
   }
   return s;


### PR DESCRIPTION
not tested.

ソースコードで`(int)`でキャストするのではなく、コンパイラによる警告表示を無効にする方法に切り替えた。