### PR TITLE
Fix ADD X-flag: Add1() must use add_conditions() not sub_conditions()

### DIFF
--- a/src/line_d.c
+++ b/src/line_d.c
@@ -148,7 +148,7 @@ static bool Add1(char code1, char code2) {
   }
 
   /* フラグの変化 */
-  sub_conditions(src_data, dest_data, result, size, true);
+  add_conditions(src_data, dest_data, result, size, true);
 
   return false;
 }


### PR DESCRIPTION
I stumbled on this while running run68, and I believe there is a bug in `add.l Dn,<ea>`.

This small example highlights the issue:

```
; addx_flag.S
;
; Bug: Add1() uses sub_conditions() instead of add_conditions().
; Add1 handles "add Dn,<ea>" where <ea> is memory.
;
; Build: vasmm68k_mot -Fxfile -o addx_flag.x addx_flag.S
; Run:   run68 addx_flag.x

        section text,code

        move.l  #$FFFFFFFF,-(sp)
        move.l  #1,d0
        add.l   d0,(sp)         ; $FFFFFFFF+1=$00000000, carry -> X=1
        clr.l   d0
        addx.l  d0,d0           ; d0 = 0+0+X = 1 if correct, 0 if bug
        add.b   #'0',d0         ; '1' if correct, '0' if bug
        move.w  d0,-(sp)
        dc.w    $FF02           ; _DOS_PUTCHAR
        addq.l  #4,sp           ; clean PUTCHAR + test value

        pea     crlf
        dc.w    $FF09           ; _DOS_PRINT
        addq.l  #4,sp

        clr.w   -(sp)
        dc.w    $FF4C           ; _DOS_EXIT2(0)

crlf:   dc.b    $0d,$0a,0
```
(I use vasm due to my background on the Amiga, but I guess HAS would build the code just fine..)

It should print `1` (the X/carry flag).